### PR TITLE
fix(local storage): Increase local storage limit to maximum 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.0.16 (TBD)
 
+### Fixes
+
+- change the local storage's length limit to the browser's maximum
+
 ### Internal
 
 - Setup `prettier`, `husky` and `lint-staged` to format the code on commit

--- a/cypress/component/terminal.cy.tsx
+++ b/cypress/component/terminal.cy.tsx
@@ -317,10 +317,13 @@ describe("ReactTerminal", () => {
 			</TerminalContextProvider>,
 		);
 
-		writeInTerminal("first");
+		const firstCommand = "first1111111111111111111111111111111111111111111111";
+		const secondCommand = "second222222222222222222222222222222222";
+
+		writeInTerminal(firstCommand);
 		writeInTerminal("Enter");
 
-		writeInTerminal("second");
+		writeInTerminal(secondCommand);
 		writeInTerminal("Enter");
 
 		cy.mount(
@@ -330,9 +333,9 @@ describe("ReactTerminal", () => {
 		);
 
 		writeInTerminal("ArrowUp");
-		cy.findByText("second");
+		cy.findByText(secondCommand);
 		writeInTerminal("ArrowUp");
-		cy.findByText("first");
+		cy.findByText(firstCommand);
 
 		cy.mount(
 			<TerminalContextProvider useLocalStorage={false}>

--- a/src/hooks/local-storage.tsx
+++ b/src/hooks/local-storage.tsx
@@ -1,4 +1,5 @@
-const CHROME_LOCAL_STORAGE_KEY_LIMIT = 20;
+// this is chrome's limit for local storage for a given key
+const CHROME_LOCAL_STORAGE_KEY_LIMIT = 5200000;
 
 const localStorageSchema = {
 	COMMAND_HISTORY: "react-terminal-plus-commandHistory",


### PR DESCRIPTION
## Description

This MR aims to fix an ongoing issue related to local storage getting cleared out just after a few commands.

**FIX**

- Altered the local storage limit from "20" to "5200000", which is the maximum for chrome.

https://github.com/singlestore-labs/react-terminal-plus/assets/24414890/b31b5712-2c7f-4c1e-9a24-da6ec52861b1

## Test

Added a new test that was previously failing and now passes.

## Changelog

Added the fix to the changelog

---

closes #7 