### PR TITLE
feat: add support for ctrl+a/e hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ The component comes with few in-built themes: `light`, `dark`, `material-light`,
 | ctrl + c | copy OR cancel running command if there is no selected text |
 | ctrl + v | paste                                                       |
 | ctrl + l | clear the console                                           |
+| ctrl + a | moves the cursor to the beginning of the line               |
+| ctrl + e | moves the cursor to the end of the line                     |
 
 ## Development
 

--- a/cypress/component/terminal.cy.tsx
+++ b/cypress/component/terminal.cy.tsx
@@ -365,6 +365,55 @@ describe("ReactTerminal", () => {
 				cy.wrap($element).should("have.css", "color", dark.themeBGColor);
 			});
 	});
+
+	it("should move the caret to the start if ctrl + a is pressed", () => {
+		cy.mount(
+			<TerminalContextProvider>
+				<ReactTerminal />
+			</TerminalContextProvider>,
+		);
+
+		writeInTerminal("db.connection.find({");
+		writeInTerminal("a", true);
+
+		// check the caret is at the start
+		cy.get('[class*="charUnderCaret"]').should("have.text", "d");
+
+		writeInTerminal("res = ");
+		writeInTerminal("a", true);
+		// check the caret is at the start again
+		cy.get('[class*="charUnderCaret"]').should("have.text", "r");
+
+		// move the caret to the right and then press ctrl + a
+		writeInTerminal("ArrowRight");
+		writeInTerminal("ArrowRight");
+		writeInTerminal("a", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "r");
+	});
+
+	it("should move the caret to the end if ctrl + e is pressed", () => {
+		cy.mount(
+			<TerminalContextProvider>
+				<ReactTerminal />
+			</TerminalContextProvider>,
+		);
+
+		writeInTerminal("db.connection.find({");
+		writeInTerminal("ArrowLeft");
+		writeInTerminal("ArrowLeft");
+		writeInTerminal("ArrowLeft");
+		cy.get('[class*="charUnderCaret"]').should("have.text", "d");
+
+		writeInTerminal("e", true);
+		// check the caret is at the end
+		cy.get('[class*="charUnderCaret"]').should("have.text", "");
+
+		// check ctrl + e works with ctrl + a
+		writeInTerminal("a", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "d");
+		writeInTerminal("e", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "");
+	});
 });
 
 function writeText(

--- a/src/contexts/TerminalContext.tsx
+++ b/src/contexts/TerminalContext.tsx
@@ -29,6 +29,8 @@ type TerminalActions =
 	| { type: "ARROW_LEFT" }
 	| { type: "ARROW_RIGHT" }
 	| { type: "RESET_CARET_POSITION" }
+	| { type: "MOVE_CARET_TO_START" }
+	| { type: "MOVE_CARET_TO_END" }
 	| { type: "UPDATE_BUFFERED_CONTENT"; payload: React.ReactNode };
 
 type TerminalContextState = {
@@ -264,6 +266,22 @@ function terminalReducer(
 						caretPosition: newCaretPosition,
 						textAfterCaret: newCaretTextAfter,
 						textBeforeCaret: newCaretTextBefore,
+					};
+				}
+				case "MOVE_CARET_TO_START": {
+					return {
+						...state,
+						caretPosition: 0,
+						textAfterCaret: state.editorInput,
+						textBeforeCaret: "",
+					};
+				}
+				case "MOVE_CARET_TO_END": {
+					return {
+						...state,
+						caretPosition: state.editorInput.length,
+						textAfterCaret: "",
+						textBeforeCaret: state.editorInput,
 					};
 				}
 				default: {

--- a/src/hooks/editor.tsx
+++ b/src/hooks/editor.tsx
@@ -196,6 +196,16 @@ export const useEditorInput = ({
 				} else {
 					cancelCommand();
 				}
+			} else if (
+				(event.metaKey || event.ctrlKey) &&
+				eventKey.toLowerCase() == "a"
+			) {
+				send({ type: "MOVE_CARET_TO_START" });
+			} else if (
+				(event.metaKey || event.ctrlKey) &&
+				eventKey.toLowerCase() == "e"
+			) {
+				send({ type: "MOVE_CARET_TO_END" });
 			} else {
 				if (eventKey && eventKey.length === 1) {
 					send({ type: "TYPE", text: eventKey });


### PR DESCRIPTION
This PR introduces two new hotkey support to the terminal:
1. Move Caret to Start of Line (Ctrl + A): When the user presses Ctrl + A, the caret will move to the start of the line. 
2. Move Caret to End of Line (Ctrl + E): When the user presses Ctrl + E, the caret will move to the end of the line.