### PR TITLE
feat: add support for ctrl+</>, Home and End hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,17 @@ The component comes with few in-built themes: `light`, `dark`, `material-light`,
 
 ## In-built shortcuts
 
-| shortcut | description                                                 |
-| -------- | ----------------------------------------------------------- |
-| ctrl + c | copy OR cancel running command if there is no selected text |
-| ctrl + v | paste                                                       |
-| ctrl + l | clear the console                                           |
-| ctrl + a | moves the cursor to the beginning of the line               |
-| ctrl + e | moves the cursor to the end of the line                     |
+| shortcut           | description                                                 |
+| ------------------ | ----------------------------------------------------------- |
+| ctrl + c           | copy OR cancel running command if there is no selected text |
+| ctrl + v           | paste                                                       |
+| ctrl + l           | clear the console                                           |
+| ctrl + a           | moves the cursor to the beginning of the line               |
+| ctrl + e           | moves the cursor to the end of the line                     |
+| Home               | moves the cursor to the beginning of the line               |
+| End                | moves the cursor to the end of the line                     |
+| ctrl + left-arrow  | moves the cursor to the backward word                       |
+| ctrl + right-arrow | moves the cursor to the forward word                        |
 
 ## Development
 

--- a/cypress/component/terminal.cy.tsx
+++ b/cypress/component/terminal.cy.tsx
@@ -414,6 +414,107 @@ describe("ReactTerminal", () => {
 		writeInTerminal("e", true);
 		cy.get('[class*="charUnderCaret"]').should("have.text", "");
 	});
+
+	it("should move the caret to the start if Home is pressed", () => {
+		cy.mount(
+			<TerminalContextProvider>
+				<ReactTerminal />
+			</TerminalContextProvider>,
+		);
+
+		writeInTerminal("db.connection.find({");
+		writeInTerminal("Home");
+
+		// check the caret is at the start
+		cy.get('[class*="charUnderCaret"]').should("have.text", "d");
+
+		writeInTerminal("res = ");
+		writeInTerminal("Home");
+		// check the caret is at the start again
+		cy.get('[class*="charUnderCaret"]').should("have.text", "r");
+
+		// move the caret to the right and then press Home
+		writeInTerminal("ArrowRight");
+		writeInTerminal("ArrowRight");
+		writeInTerminal("Home");
+		cy.get('[class*="charUnderCaret"]').should("have.text", "r");
+	});
+
+	it("should move the caret to the end if End is pressed", () => {
+		cy.mount(
+			<TerminalContextProvider>
+				<ReactTerminal />
+			</TerminalContextProvider>,
+		);
+
+		writeInTerminal("db.connection.find({");
+		writeInTerminal("ArrowLeft");
+		writeInTerminal("ArrowLeft");
+		writeInTerminal("ArrowLeft");
+		cy.get('[class*="charUnderCaret"]').should("have.text", "d");
+
+		writeInTerminal("End");
+		// check the caret is at the end
+		cy.get('[class*="charUnderCaret"]').should("have.text", "");
+
+		// check End works with Home
+		writeInTerminal("Home");
+		cy.get('[class*="charUnderCaret"]').should("have.text", "d");
+		writeInTerminal("End");
+		cy.get('[class*="charUnderCaret"]').should("have.text", "");
+	});
+
+	it("should move the caret to the backward word if ctrl + < is pressed", () => {
+		cy.mount(
+			<TerminalContextProvider>
+				<ReactTerminal />
+			</TerminalContextProvider>,
+		);
+
+		writeInTerminal("is singlestore kai");
+		writeInTerminal("ArrowLeft", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "k");
+
+		writeInTerminal("ArrowLeft", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "s");
+
+		writeInTerminal("ArrowLeft", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "i");
+
+		writeInTerminal("this ");
+		writeInTerminal("ArrowLeft", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "t");
+	});
+
+	it("should move the caret to the forward word if ctrl + > is pressed", () => {
+		cy.mount(
+			<TerminalContextProvider>
+				<ReactTerminal />
+			</TerminalContextProvider>,
+		);
+
+		writeInTerminal("this is singlestore kai");
+
+		// move the caret to the start
+		writeInTerminal("a", true);
+		writeInTerminal("ArrowRight", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "i");
+
+		writeInTerminal("ArrowRight", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "s");
+
+		writeInTerminal("ArrowRight", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "k");
+
+		writeInTerminal("not");
+		writeInTerminal("ArrowRight", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "");
+
+		// try with ctrl + <
+		writeInTerminal("ArrowLeft", true);
+		writeInTerminal("ArrowRight", true);
+		cy.get('[class*="charUnderCaret"]').should("have.text", "");
+	});
 });
 
 function writeText(
@@ -431,6 +532,8 @@ function writeText(
 			"ArrowLeft",
 			"ArrowRight",
 			"Tab",
+			"Home",
+			"End",
 		].includes(value)
 	) {
 		container.trigger("keydown", {

--- a/cypress/component/terminal.cy.tsx
+++ b/cypress/component/terminal.cy.tsx
@@ -464,7 +464,7 @@ describe("ReactTerminal", () => {
 		cy.get('[class*="charUnderCaret"]').should("have.text", "");
 	});
 
-	it("should move the caret to the backward word if ctrl + < is pressed", () => {
+	it("should move the caret to the backward word if ctrl + ArrowLeft is pressed", () => {
 		cy.mount(
 			<TerminalContextProvider>
 				<ReactTerminal />
@@ -486,7 +486,7 @@ describe("ReactTerminal", () => {
 		cy.get('[class*="charUnderCaret"]').should("have.text", "t");
 	});
 
-	it("should move the caret to the forward word if ctrl + > is pressed", () => {
+	it("should move the caret to the forward word if ctrl + ArrowRight is pressed", () => {
 		cy.mount(
 			<TerminalContextProvider>
 				<ReactTerminal />

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -5,4 +5,36 @@ export default class Utils {
 		}
 		return [value.substring(0, index), value.substring(index)];
 	}
+
+	static splitStringAtNextSpace(value: string, index: number) {
+		if (!value) {
+			return ["", ""];
+		}
+		let nextSpacePos = value.indexOf(" ", index);
+		// If there is no space after the index, return the whole string
+		if (nextSpacePos === -1) {
+			nextSpacePos = value.length;
+		}
+		// Skip all consecutive spaces
+		while (nextSpacePos < value.length && value[nextSpacePos] === " ") {
+			nextSpacePos++;
+		}
+		return [value.substring(0, nextSpacePos), value.substring(nextSpacePos)];
+	}
+
+	static splitStringAtPreviousSpace(value: string, index: number) {
+		if (!value) {
+			return ["", ""];
+		}
+		// Find the position of the previous space
+		// trimEnd() is used to remove any trailing spaces
+		let prevSpacePos = value.substring(0, index).trimEnd().lastIndexOf(" ");
+		if (prevSpacePos === -1 || prevSpacePos === 0) {
+			prevSpacePos = 0;
+		} else {
+			// move the position to the next character after the space
+			prevSpacePos = prevSpacePos + 1;
+		}
+		return [value.substring(0, prevSpacePos), value.substring(prevSpacePos)];
+	}
 }

--- a/src/contexts/TerminalContext.tsx
+++ b/src/contexts/TerminalContext.tsx
@@ -31,6 +31,8 @@ type TerminalActions =
 	| { type: "RESET_CARET_POSITION" }
 	| { type: "MOVE_CARET_TO_START" }
 	| { type: "MOVE_CARET_TO_END" }
+	| { type: "FORWARD_WORD" }
+	| { type: "BACKWARD_WORD" }
 	| { type: "UPDATE_BUFFERED_CONTENT"; payload: React.ReactNode };
 
 type TerminalContextState = {
@@ -268,6 +270,26 @@ function terminalReducer(
 						textBeforeCaret: newCaretTextBefore,
 					};
 				}
+				case "FORWARD_WORD": {
+					const [newCaretTextBefore, newCaretTextAfter] =
+						moveCaretForwardByOneWord(state.editorInput, state.caretPosition);
+					return {
+						...state,
+						caretPosition: newCaretTextBefore.length,
+						textAfterCaret: newCaretTextAfter,
+						textBeforeCaret: newCaretTextBefore,
+					};
+				}
+				case "BACKWARD_WORD": {
+					const [newCaretTextBefore, newCaretTextAfter] =
+						moveCaretBackwardByOneWord(state.editorInput, state.caretPosition);
+					return {
+						...state,
+						caretPosition: newCaretTextBefore.length,
+						textAfterCaret: newCaretTextAfter,
+						textBeforeCaret: newCaretTextBefore,
+					};
+				}
 				case "MOVE_CARET_TO_START": {
 					return {
 						...state,
@@ -293,6 +315,28 @@ function terminalReducer(
 			return state;
 		}
 	}
+}
+
+function moveCaretForwardByOneWord(
+	newEditorInput: string,
+	newCaretPosition: number,
+) {
+	const [caretTextBefore, caretTextAfter] = Utils.splitStringAtNextSpace(
+		newEditorInput,
+		newCaretPosition,
+	);
+	return [caretTextBefore, caretTextAfter];
+}
+
+function moveCaretBackwardByOneWord(
+	newEditorInput: string,
+	newCaretPosition: number,
+) {
+	const [caretTextBefore, caretTextAfter] = Utils.splitStringAtPreviousSpace(
+		newEditorInput,
+		newCaretPosition,
+	);
+	return [caretTextBefore, caretTextAfter];
 }
 
 function caretTextBeforeUpdate(state: TerminalState) {

--- a/src/hooks/editor.tsx
+++ b/src/hooks/editor.tsx
@@ -162,6 +162,10 @@ export const useEditorInput = ({
 				} else {
 					send({ type: "RESET_CARET_POSITION" });
 				}
+			} else if ((event.metaKey || event.ctrlKey) && eventKey === "ArrowLeft") {
+				send({ type: "BACKWARD_WORD" });
+			} else if ((event.metaKey || event.ctrlKey) && eventKey == "ArrowRight") {
+				send({ type: "FORWARD_WORD" });
 			} else if (eventKey === "ArrowLeft") {
 				if (store.caretPosition > 0) {
 					send({ type: "ARROW_LEFT" });
@@ -197,13 +201,13 @@ export const useEditorInput = ({
 					cancelCommand();
 				}
 			} else if (
-				(event.metaKey || event.ctrlKey) &&
-				eventKey.toLowerCase() == "a"
+				((event.metaKey || event.ctrlKey) && eventKey.toLowerCase() == "a") ||
+				eventKey === "Home"
 			) {
 				send({ type: "MOVE_CARET_TO_START" });
 			} else if (
-				(event.metaKey || event.ctrlKey) &&
-				eventKey.toLowerCase() == "e"
+				((event.metaKey || event.ctrlKey) && eventKey.toLowerCase() == "e") ||
+				eventKey === "End"
 			) {
 				send({ type: "MOVE_CARET_TO_END" });
 			} else {


### PR DESCRIPTION
This PR introduces two new hotkey support to the terminal:

1. Move to the forward word(ctrl+ArrowRight): When the user presses ctrl+ArrowRight, the caret will move to the start of the next word.
2. Move to the forward word(ctrl+ArrowLeft: When the user presses ctrl+ArrowLeft, the caret will move to the start of the previous word.
3. Move Caret to Start of Line (Home): When the user presses Home, the caret will move to the start of the line.
4. Move Caret to End of Line (End): When the user presses End, the caret will move to the end of the line.