### PR TITLE
Remove CSS which makes selection not visible.

### DIFF
--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -13,12 +13,6 @@
 		border-radius: 5px;
 	}
 
-	// prevents style effects on copy/paste
-	caret-color: transparent;
-	&::selection {
-		background: transparent;
-	}
-
 	--scroll-bar-thumb-color: transparent;
 	--scroll-bar-track-color: transparent;
 	--scroll-bar-width: 10px;


### PR DESCRIPTION
Removing the CSS which makes the background `transparent` when characters are selected. This made it not possible to visualize a selection.